### PR TITLE
Modification clavier.json

### DIFF
--- a/clavier.json
+++ b/clavier.json
@@ -52,7 +52,7 @@
             "legend" : "symbole pour et"
         },
         {
-            "row": 0,
+            "row": 1,
             "column": 3,
             "character": "ꝰ",
             "legend" : "symbole pour -us"


### PR DESCRIPTION
Le symbole pour -us avait été indexé à la première ligne au lieu d'être indexé à la deuxième et il prenait la place du i suscrit.