### PR TITLE
Modification clavier.json (hyphenation)

### DIFF
--- a/clavier.json
+++ b/clavier.json
@@ -28,7 +28,7 @@
             "legend" : "i suscrit pour q"
         },
         {
-            "row": 1,
+            "row": 0,
             "column": 4,
             "character": "\u2e17",
             "legend": "hyphenation double oblique"


### PR DESCRIPTION
La double hyphenation était à la deuxième ligne au lieu d'être sur la première et était écrasé par le symbole pour -ur.