### PR TITLE
Update clavier.json, suppression macron, ajout p barré

### DIFF
--- a/clavier.json
+++ b/clavier.json
@@ -18,20 +18,20 @@
         {
             "row": 0,
             "column": 2,
-            "character": "\u0304",
-            "legend" : "macron pour q"
-        },
-        {
-            "row": 0,
-            "column": 3,
             "character": "\u0365",
             "legend" : "i suscrit pour q"
         },
         {
             "row": 0,
-            "column": 4,
+            "column": 3,
             "character": "\u2e17",
             "legend": "hyphenation double oblique"
+        },
+        {
+            "row": 0,
+            "column": 4,
+            "character": "ꝑ",
+            "legend" : "p barré pour per/par"
         },
         {
             "row": 1,


### PR DESCRIPTION
Suppression du macron qui finalement n'était pas pertinent pour notre texte puisqu'il n'y avait pas de différence visible entre un macron et un tilde.  
Ajout du p barré, qui se trouve une fois à la page 3 et plusieurs fois à la page 6.